### PR TITLE
Fix/streaming endpoint sqlite lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ ENV PATH="/home/dataline/backend/venv/bin:$PATH"
 # Copy in backend files
 WORKDIR /home/dataline/backend
 COPY backend/*.py .
+COPY backend/samples ./samples
 COPY backend/dataline ./dataline
 COPY backend/alembic ./alembic
 COPY backend/alembic.ini .

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     - [Windows](#windows)
     - [Mac](#mac)
     - [Linux](#linux)
+    - [Docker](#docker)
     - [Running manually](#running-manually)
   - [Startup Quest](#startup-quest)
 
@@ -72,6 +73,25 @@ You can use Homebrew, see the [Mac](#mac) section.
 
 You may also wish to use the binary instead, to do so, follow the instructions in the [Windows](#windows) section, and use the `dataline-linux.tar.zip` file instead.
 
+#### Docker
+
+You can also use our official docker image and get started in one command. This is more suitable for business use:
+
+```bash
+docker run -p 2222:2222 -p 7377:7377 -v dataline:/home/.dataline --name dataline ramiawar/dataline:latest
+```
+
+You can manage this as you would any other container. `docker start dataline`, `docker stop dataline`
+
+For updating to a new version, just remove the container and rerun the command. This way the volume is persisted across updates.
+
+```bash
+docker rm dataline
+docker run -p 2222:2222 -p 7377:7377 -v dataline:/home/.dataline --name dataline ramiawar/dataline:latest
+```
+
+To connect to the frontend, you can then visit:
+[http://localhost:2222](http://localhost:2222)
 
 #### Running manually
 

--- a/backend/dataline/api/conversation/router.py
+++ b/backend/dataline/api/conversation/router.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends
 from fastapi.responses import StreamingResponse
 from langchain_community.utilities.sql_database import SQLDatabase
+from starlette.background import BackgroundTask
 
 from dataline.models.conversation.schema import (
     ConversationOut,
@@ -16,7 +17,7 @@ from dataline.models.llm_flow.schema import SQLQueryRunResult
 from dataline.models.message.schema import MessageOptions, MessageWithResultsOut
 from dataline.models.result.schema import ResultOut
 from dataline.old_models import SuccessListResponse, SuccessResponse
-from dataline.repositories.base import AsyncSession, get_session
+from dataline.repositories.base import AsyncSession, get_session, get_session_no_commit
 from dataline.services.connection import ConnectionService
 from dataline.services.conversation import ConversationService
 from dataline.services.llm_flow.toolkit import execute_sql_query
@@ -99,12 +100,24 @@ def query(
     conversation_id: UUID,
     query: str,
     message_options: Annotated[MessageOptions, Body(embed=True)],
-    session: AsyncSession = Depends(get_session),
+    session: AsyncSession = Depends(get_session_no_commit),
     conversation_service: ConversationService = Depends(),
 ):
+    async def commit_and_close_session():
+        try:
+            # Commit only if no exception occurs
+            await session.commit()
+        except Exception:
+            # If any exception encountered, rollback all changes
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
     return StreamingResponse(
         conversation_service.query(session, conversation_id, query, secure_data=message_options.secure_data),
         media_type="text/event-stream",
+        background=BackgroundTask(commit_and_close_session),  # this only runs after the query is finished
     )
 
 

--- a/backend/dataline/repositories/base.py
+++ b/backend/dataline/repositories/base.py
@@ -28,6 +28,13 @@ SessionCreator = async_sessionmaker(autocommit=False, autoflush=False, bind=engi
 AsyncSession = _AsyncSession
 
 
+async def get_session_no_commit() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency to get a db session without committing or closing"""
+    session = SessionCreator()
+    await session.execute(text("PRAGMA foreign_keys=ON"))
+    yield session
+
+
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     """FastAPI dependency to get a db session"""
     session = SessionCreator()


### PR DESCRIPTION
*Issue #, if available:*
#190 

*Description of changes:*
There's a breaking change in the newer versions of fastapi changing the behavior `Depends` w.r.t. background tasks and streaming responses. The session was being committed and closed before the query was able to run.

Changes: used a `get_session_no_commit` depends so that we manually commit and close the session after the query runs.
Also brought back Docker as it was innocent this entire time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
