### PR TITLE
Redirect to root page if chat id not found

### DIFF
--- a/frontend/src/components/Conversation/Conversation.tsx
+++ b/frontend/src/components/Conversation/Conversation.tsx
@@ -1,9 +1,5 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  // useState
-} from "react";
+import { useEffect, useRef, useState } from "react";
+import { isAxiosError } from "axios";
 import { Message } from "./Message";
 import { Navigate, useParams } from "react-router-dom";
 import ExpandingInput from "./ExpandingInput";
@@ -113,19 +109,21 @@ export const Conversation = () => {
       </div>
     );
   }
+
+  if (
+    (isAxiosError(getMessagesError) &&
+      getMessagesError.response?.status === 404) ||
+    !connectionsData?.connections?.length
+  ) {
+    return <Navigate to={Routes.Root} />;
+  }
+
   if (!isSuccessGetMessages) {
     return (
       <div className="w-full h-screen flex justify-center items-center text-white">
         Something went wrong!
       </div>
     );
-  }
-  if (
-    // @ts-expect-error, status is not known
-    getMessagesError?.status === 404 ||
-    !connectionsData?.connections?.length
-  ) {
-    return <Navigate to={Routes.Root} />;
   }
 
   return (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, opening a chat page with a conversation ID that doesn't exist would just show "something went wrong!". Now, we redirect to Root upon 404 response for the given ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
