### PR TITLE
make settings update a proper PATCH request

### DIFF
--- a/backend/dataline/models/user/schema.py
+++ b/backend/dataline/models/user/schema.py
@@ -38,8 +38,8 @@ class UserUpdateIn(BaseModel):
         return v.get_secret_value()
 
     @field_serializer("langsmith_api_key")
-    def dump_langsmith_api_key(self, v: SecretStr) -> str:
-        return v.get_secret_value()
+    def dump_langsmith_api_key(self, v: SecretStr | None) -> str | None:
+        return v.get_secret_value() if v else None
 
 
 class UserOut(BaseModel):

--- a/backend/dataline/repositories/base.py
+++ b/backend/dataline/repositories/base.py
@@ -295,7 +295,7 @@ class BaseRepository(ABC, Generic[Model, TCreate, TUpdate]):
         query = (
             update(self.model)
             .filter_by(id=record_id)
-            .values(**data.model_dump(exclude_defaults=True))
+            .values(**data.model_dump(exclude_unset=True))
             .returning(self.model)
         )
         return await self.update_one(session, query)

--- a/backend/dataline/services/settings.py
+++ b/backend/dataline/services/settings.py
@@ -79,7 +79,7 @@ class SettingsService:
         user_info = await self.user_repo.get_one_or_none(session)
         if user_info is None:
             # Create user with data
-            user_create = UserCreate.model_construct(**data.model_dump(exclude_none=True))
+            user_create = UserCreate.model_construct(**data.model_dump(exclude_unset=True))
             if user_create.openai_api_key and user_create.preferred_openai_model is None:
                 user_create.preferred_openai_model = (
                     config.default_model
@@ -91,7 +91,7 @@ class SettingsService:
                 setup_sentry()
         else:
             # Update user with data
-            user_update = UserUpdate.model_construct(**data.model_dump(exclude_none=True))
+            user_update = UserUpdate.model_construct(**data.model_dump(exclude_unset=True))
             if user_update.openai_api_key:
                 key_to_check = user_update.openai_api_key
                 model_to_check = (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -4,6 +4,7 @@ import {
   IMessageOut,
   IMessageWithResultsOut,
   IResult,
+  IUserInfo,
 } from "./components/Library/types";
 import { IEditConnection } from "./components/Library/types";
 import { apiURL, backendApi } from "./services/api_client";
@@ -289,7 +290,7 @@ const updateAvatar = async (file: File) => {
 };
 
 // Optional name or openai_api_key
-export type UpdateUserInfoResult = ApiResponse<void>;
+export type UpdateUserInfoResult = ApiResponse<IUserInfo>;
 const updateUserInfo = async (options: {
   name?: string;
   openai_api_key?: string;
@@ -298,26 +299,24 @@ const updateUserInfo = async (options: {
 }) => {
   const { name, openai_api_key, langsmith_api_key, sentry_enabled } = options;
   // send only the filled in fields
-  const data = {
+  const data: Partial<IUserInfo> = {
     ...(name && { name }),
     ...(openai_api_key && { openai_api_key }),
-    ...(langsmith_api_key && { langsmith_api_key }),
     ...(sentry_enabled != null && { sentry_enabled }),
   };
+  if (langsmith_api_key !== undefined) {
+    data.langsmith_api_key =
+      langsmith_api_key === "" ? null : langsmith_api_key;
+  }
   const response = await backendApi<UpdateUserInfoResult>({
-    url: `/settings/info`,
+    url: "/settings/info",
     method: "patch",
     data,
   });
   return response.data;
 };
 
-export type GetUserInfoResult = ApiResponse<{
-  name: string;
-  openai_api_key: string;
-  langsmith_api_key?: string;
-  sentry_enabled: boolean;
-}>;
+export type GetUserInfoResult = ApiResponse<IUserInfo>;
 const getUserInfo = async () => {
   return (await backendApi<GetUserInfoResult>({ url: `/settings/info` })).data;
 };

--- a/frontend/src/components/Library/types.ts
+++ b/frontend/src/components/Library/types.ts
@@ -113,3 +113,10 @@ export interface IEditConnection {
   name: string;
   dsn: string;
 }
+
+export interface IUserInfo {
+  name: string;
+  openai_api_key: string;
+  langsmith_api_key?: string | null;
+  sentry_enabled: boolean;
+}

--- a/frontend/src/hooks/settings.ts
+++ b/frontend/src/hooks/settings.ts
@@ -146,12 +146,12 @@ export function useUpdateUserAvatar(options = {}) {
 export function useUpdateUserInfo(options = {}) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (payload: {
+    mutationFn: async (payload: {
       openai_api_key?: string;
       name?: string;
       langsmith_api_key?: string;
       sentry_enabled?: boolean;
-    }) => api.updateUserInfo(payload),
+    }) => (await api.updateUserInfo(payload)).data,
     onSuccess() {
       enqueueSnackbar({
         variant: "success",


### PR DESCRIPTION
*Issue #, if available:*
#174 
*Description of changes:*
Backend:
- use `exclude_unset` instead of `exclude_default` of the `model_dump` function when updating by uuid
- use `exclude_unset` instead of `exclude_none` when model dumping in `update_user_info`

Frontend:
- when patching user info, only include values that have changed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
