### PR TITLE
S14.00 bug sample db persistence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,4 +29,6 @@ jobs:
       - name: Install the project dependencies
         run: poetry install --with dev --no-interaction --no-root
       - name: Run the automated tests (for example)
+        env:
+          DATA_DIRECTORY: ./data
         run: PYTHONPATH=. poetry run pytest .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,5 @@ jobs:
         run: poetry install --with dev --no-interaction --no-root
       - name: Run the automated tests (for example)
         env:
-          DATA_DIRECTORY: ./data
+          DATA_DIRECTORY: ./
         run: PYTHONPATH=. poetry run pytest .

--- a/backend/dataline/api/connection/router.py
+++ b/backend/dataline/api/connection/router.py
@@ -29,6 +29,17 @@ async def connect_db(
     session: AsyncSession = Depends(get_session),
     connection_service: ConnectionService = Depends(ConnectionService),
 ) -> SuccessResponse[ConnectionOut]:
+    connection = await connection_service.create_connection(session, dsn=req.dsn, name=req.name, is_sample=False)
+    return SuccessResponse(data=connection)
+
+
+@router.post("/connect/sample", response_model_exclude_none=True)
+async def connect_sample_db(
+    req: ConnectRequest,
+    session: AsyncSession = Depends(get_session),
+    connection_service: ConnectionService = Depends(ConnectionService),
+) -> SuccessResponse[ConnectionOut]:
+    # TODO: Identify sample, copy file in, then create connection
     connection = await connection_service.create_connection(
         session, dsn=req.dsn, name=req.name, is_sample=req.is_sample
     )
@@ -48,7 +59,7 @@ async def connect_db_from_file(
         if not is_valid_sqlite_file(file):
             raise HTTPException(status_code=400, detail="File provided must be a valid SQLite file.")
 
-        connection = await connection_service.create_sqlite_connection(session, file, name)
+        connection = await connection_service.create_sqlite_connection(session, file.file, name)
         return SuccessResponse(data=connection)
 
     elif type == FileConnectionType.csv:

--- a/backend/dataline/api/connection/router.py
+++ b/backend/dataline/api/connection/router.py
@@ -47,7 +47,9 @@ async def connect_sample_db(
     # Copy file to user data directory and create connection
     sample_path = sample[1]
     with open(sample_path, "rb") as f:
-        connection = await connection_service.create_sqlite_connection(session, file=f, name=sample[0], is_sample=True)
+        connection = await connection_service.create_sqlite_connection(
+            session, file=f, name=req.connection_name, is_sample=True
+        )
     return SuccessResponse(data=connection)
 
 

--- a/backend/dataline/models/connection/schema.py
+++ b/backend/dataline/models/connection/schema.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from dataline.config import config
+
 
 class Connection(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -70,6 +72,7 @@ class TableSchemasOut(BaseModel):
 
 
 class SampleOut(BaseModel):
+    key: str
     title: str
     file: str
     link: str
@@ -137,3 +140,28 @@ class ConnectionUpdateIn(BaseModel):
 class FileConnectionType(Enum):
     sqlite = "sqlite"
     csv = "csv"
+
+
+class SampleName(Enum):
+    dvdrental = "dvdrental"
+    netflix = "netflix"
+    titanic = "titanic"
+
+
+class ConnectSampleIn(BaseModel):
+    sample_name: SampleName
+
+
+DB_SAMPLES = {
+    "dvdrental": (
+        "Dvd Rental",
+        config.sample_dvdrental_path,
+        "https://www.postgresqltutorial.com/postgresql-getting-started/postgresql-sample-database/",
+    ),
+    "netflix": ("Netflix Shows", config.sample_netflix_path, "https://www.kaggle.com/datasets/shivamb/netflix-shows"),
+    "titanic": (
+        "Titanic",
+        config.sample_titanic_path,
+        "https://www.kaggle.com/datasets/ibrahimelsayed182/titanic-dataset",
+    ),
+}

--- a/backend/dataline/models/connection/schema.py
+++ b/backend/dataline/models/connection/schema.py
@@ -150,6 +150,7 @@ class SampleName(Enum):
 
 class ConnectSampleIn(BaseModel):
     sample_name: SampleName
+    connection_name: str
 
 
 DB_SAMPLES = {

--- a/backend/dataline/services/connection.py
+++ b/backend/dataline/services/connection.py
@@ -1,6 +1,7 @@
 import logging
 import sqlite3
 from pathlib import Path
+from typing import BinaryIO
 from uuid import UUID
 
 import pandas as pd
@@ -128,12 +129,11 @@ class ConnectionService:
         updated_connection = await self.connection_repo.update_by_uuid(session, connection_uuid, update)
         return ConnectionOut.model_validate(updated_connection)
 
-    async def create_sqlite_connection(self, session: AsyncSession, file: UploadFile, name: str) -> ConnectionOut:
-        # Store file in data directory
+    async def create_sqlite_connection(self, session: AsyncSession, file: BinaryIO, name: str) -> ConnectionOut:
         generated_name = generate_short_uuid() + ".sqlite"
         file_path = Path(config.data_directory) / generated_name
         with file_path.open("wb") as f:
-            f.write(file.file.read())
+            f.write(file.read())
 
         # Create connection with the locally copied file
         dsn = get_sqlite_dsn(str(file_path.absolute()))

--- a/backend/dataline/services/connection.py
+++ b/backend/dataline/services/connection.py
@@ -129,7 +129,9 @@ class ConnectionService:
         updated_connection = await self.connection_repo.update_by_uuid(session, connection_uuid, update)
         return ConnectionOut.model_validate(updated_connection)
 
-    async def create_sqlite_connection(self, session: AsyncSession, file: BinaryIO, name: str) -> ConnectionOut:
+    async def create_sqlite_connection(
+        self, session: AsyncSession, file: BinaryIO, name: str, is_sample: bool = False
+    ) -> ConnectionOut:
         generated_name = generate_short_uuid() + ".sqlite"
         file_path = Path(config.data_directory) / generated_name
         with file_path.open("wb") as f:
@@ -137,7 +139,7 @@ class ConnectionService:
 
         # Create connection with the locally copied file
         dsn = get_sqlite_dsn(str(file_path.absolute()))
-        return await self.create_connection(session, dsn=dsn, name=name, is_sample=False)
+        return await self.create_connection(session, dsn=dsn, name=name, is_sample=is_sample)
 
     async def create_csv_connection(self, session: AsyncSession, file: UploadFile, name: str) -> ConnectionOut:
         generated_name = generate_short_uuid() + ".sqlite"

--- a/backend/tests/api/connection/test_connection.py
+++ b/backend/tests/api/connection/test_connection.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from dataline.config import config
-from dataline.models.connection.schema import Connection
+from dataline.models.connection.schema import DB_SAMPLES, Connection
 from dataline.utils.utils import get_sqlite_dsn
 
 logger = logging.getLogger(__name__)
@@ -32,36 +32,29 @@ async def test_connect_db(client: TestClient) -> None:
     # Delete database after tests
     pathlib.Path("test.db").unlink(missing_ok=True)
 
-    # TODO: Remove after sqlalchemy migration
-    # Manual rollback
-    client.delete(f"/connection/{data['id']}")
-
 
 @pytest.mark.asyncio
 async def test_connect_sample_db(client: TestClient) -> None:
     connection_in = {
-        "dsn": "sqlite:///test.db",
-        "name": "Test",
-        "is_sample": True,
+        "sample_name": "dvdrental",
+        "connection_name": "My DB",
     }
-    response = client.post("/connect", json=connection_in)
+    response = client.post("/connect/sample", json=connection_in)
 
     assert response.status_code == 200
 
     data = response.json()["data"]
     assert data["id"]
-    assert data["dsn"] == connection_in["dsn"]
-    assert data["name"] == connection_in["name"]
+    assert data["dsn"] is not None
+    assert data["dsn"].startswith("sqlite:///")
+    assert data["name"] == connection_in["connection_name"]
     assert data["dialect"] == "sqlite"
     assert data["database"]
     assert data["is_sample"] is True
 
     # Delete database after tests
-    pathlib.Path("test.db").unlink(missing_ok=True)
-
-    # TODO: Remove after sqlalchemy migration
-    # Manual rollback
-    client.delete(f"/connection/{data['id']}")
+    file_path = data["dsn"].replace("sqlite:///", "")
+    pathlib.Path(file_path).unlink(missing_ok=True)
 
 
 @pytest.mark.asyncio
@@ -73,14 +66,10 @@ async def test_create_sample_db_connection_twice_409(client: TestClient) -> None
     }
     response = client.post("/connect", json=connection_in)
     assert response.status_code == 200
-    connection = Connection(**response.json()["data"])
+    Connection(**response.json()["data"])
 
     response = client.post("/connect", json=connection_in)
     assert response.status_code == 409
-
-    # TODO: Remove after sqlalchemy migration
-    # Manual rollback
-    client.delete(f"/connection/{str(connection.id)}")
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -48,6 +48,18 @@ const createConnection = async (
   return response.data;
 };
 
+const createSampleConnection = async (
+  sampleName: string,
+  connectionName: string
+): Promise<ConnectResult> => {
+  const response = await backendApi<ConnectResult>({
+    url: "/connect/sample",
+    method: "post",
+    data: { sample_name: sampleName, connection_name: connectionName },
+  });
+  return response.data;
+};
+
 const createFileConnection = async (
   file: File,
   name: string,
@@ -85,6 +97,7 @@ const getConnection = async (
 };
 
 export type SampleResult = {
+  key: string;
   title: string;
   file: string;
   link: string;
@@ -361,6 +374,7 @@ export const api = {
   getConnection,
   getSamples,
   createConnection,
+  createSampleConnection,
   createFileConnection,
   updateConnection,
   deleteConnection,

--- a/frontend/src/components/Connection/SampleSelector.tsx
+++ b/frontend/src/components/Connection/SampleSelector.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { SampleResult } from "../../api";
 import { enqueueSnackbar } from "notistack";
 import { Button } from "@catalyst/button";
-import { useCreateConnection, useGetSamples } from "@/hooks";
+import { useCreateSampleConnection, useGetSamples } from "@/hooks";
 import { useNavigate } from "react-router-dom";
 import { Routes } from "@/router";
 
@@ -14,7 +14,7 @@ export const SampleSelector = ({ name = null }: { name: string | null }) => {
 
   const { data } = useGetSamples();
   const samples = data || [];
-  const { mutate } = useCreateConnection({
+  const { mutate } = useCreateSampleConnection({
     onSuccess: () => {
       enqueueSnackbar({
         variant: "success",
@@ -35,7 +35,7 @@ export const SampleSelector = ({ name = null }: { name: string | null }) => {
       } else {
         name = name + " (Sample)";
       }
-      mutate({ dsn: selectedSample.file, name, isSample: true });
+      mutate({ key: selectedSample.key, name });
     } else {
       enqueueSnackbar("Please select a sample dataset.", { variant: "info" });
     }
@@ -44,7 +44,7 @@ export const SampleSelector = ({ name = null }: { name: string | null }) => {
   const handleRadioChange = (selection: string) => {
     const selectedValue = selection as string;
     const selectedSample = samples.find(
-      (sample) => sample.file === selectedValue
+      (sample) => sample.key === selectedValue
     );
     setSelectedSample(selectedSample || null);
   };
@@ -56,7 +56,7 @@ export const SampleSelector = ({ name = null }: { name: string | null }) => {
       <RadioGroup name="sample" defaultValue="" onChange={handleRadioChange}>
         {samples.map((sample, index) => (
           <RadioField key={index}>
-            <Radio value={sample.file} color="white" />
+            <Radio value={sample.key} color="white" />
             <Label className="cursor-pointer">{sample.title}</Label>
             <Description>{sample.link}</Description>
           </RadioField>

--- a/frontend/src/hooks/connections.ts
+++ b/frontend/src/hooks/connections.ts
@@ -56,7 +56,12 @@ export function useGetConnection(id?: string) {
 }
 
 const defaultCreateErrorHandler = (err: Error) => {
-  if (!isAxiosError(err)) {
+  if (isAxiosError(err) && err.response?.status === 404) {
+    enqueueSnackbar({
+      variant: "error",
+      message: "Sample not found",
+    });
+  } else if (!isAxiosError(err)) {
     enqueueSnackbar({
       variant: "error",
       message: "Error creating connection.",
@@ -104,6 +109,21 @@ export function useCreateConnection(options = {}) {
       name: string;
       isSample: boolean;
     }) => api.createConnection(dsn, name, isSample),
+    onSettled() {
+      queryClient.invalidateQueries({
+        queryKey: getConnectionsQuery().queryKey,
+      });
+    },
+    onError: defaultCreateErrorHandler,
+    ...options,
+  });
+}
+
+export function useCreateSampleConnection(options = {}) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ key, name }: { key: string; name: string }) =>
+      api.createSampleConnection(key, name),
     onSettled() {
       queryClient.invalidateQueries({
         queryKey: getConnectionsQuery().queryKey,


### PR DESCRIPTION
*Issue #, if available:*  Closes  #201 

*Description of changes:* Bug happened in binaries where sample DSN was referencing a file inside the binary. 
This resulted in linking to var folders on different OSes, which are bound to get deleted.

With this change, we copy the SQLite file to the data folder on user's machine first, and then create the connection referencing that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
