### PR TITLE
feat: Stored sql run result

### DIFF
--- a/backend/dataline/main.py
+++ b/backend/dataline/main.py
@@ -6,23 +6,18 @@ import webbrowser
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
-from uuid import UUID
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from pydantic.json import pydantic_encoder
 
 from alembic import command
 from alembic.config import Config
 from dataline.app import App
 from dataline.config import IS_BUNDLED, config
-from dataline.old_models import SuccessResponse, UnsavedResult
-from dataline.repositories.base import AsyncSession, NotFoundError, get_session
+from dataline.old_models import SuccessResponse
 from dataline.sentry import maybe_init_sentry
-from dataline.services.connection import ConnectionService
-from dataline.services.conversation import ConversationService
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/backend/dataline/models/conversation/schema.py
+++ b/backend/dataline/models/conversation/schema.py
@@ -8,6 +8,7 @@ from dataline.models.llm_flow.enums import QueryResultType
 from dataline.models.llm_flow.schema import (
     ChartGenerationResult,
     SelectedTablesResult,
+    SQLQueryRunResult,
     SQLQueryStringResult,
 )
 from dataline.models.message.schema import MessageOut, MessageWithResultsOut
@@ -55,6 +56,8 @@ def render_stored_results(results: list[ResultModel]) -> list[ResultOut]:
             rendered_results.append(SelectedTablesResult.deserialize(result).serialize_result())
         elif QueryResultType(result.type) == QueryResultType.CHART_GENERATION_RESULT:
             rendered_results.append(ChartGenerationResult.deserialize(result).serialize_result())
+        elif QueryResultType(result.type) == QueryResultType.SQL_QUERY_RUN_RESULT:
+            rendered_results.append(SQLQueryRunResult.deserialize(result).serialize_result())
 
     return rendered_results
 

--- a/frontend/src/components/Conversation/MessageResultRenderer.tsx
+++ b/frontend/src/components/Conversation/MessageResultRenderer.tsx
@@ -220,6 +220,7 @@ export const MessageResultRenderer = ({
                 <DynamicTable
                   key={`message-${messageId}-table-${result.linked_id}`}
                   data={result.content}
+                  initialCreatedAt={new Date(result.created_at as string)}
                 />
               )) ||
               (result.type === "SQL_QUERY_STRING_RESULT" && (


### PR DESCRIPTION
WIP

- [x] Store sql run result
- [ ] Add delete result button (otherwise problematic for results with massive limits)
- [ ] Enforce limits by default (user-overridable)
- [ ] When query is replayed, delete old result and replace with new data + creation date
- [ ] Add refresh button to table result (does the same as above)
- [ ] Add created_at date to table result (maybe make hideable, iterate on designs) (necessary for dashboards later)