### PR TITLE
Docker cors fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,8 @@ ARG AUTH_USERNAME
 ENV AUTH_USERNAME=$AUTH_USERNAME
 ARG AUTH_PASSWORD
 ENV AUTH_PASSWORD=$AUTH_PASSWORD
+ARG ALLOWED_ORIGINS
+ENV ALLOWED_ORIGINS=$ALLOWED_ORIGINS
 
 # Running alembic and uvicorn without combining them in a bash -c command won't work
 CMD ["bash", "-c", "python -m dataline.main"]

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@
 - [Who is this for](#who-is-this-for)
 - [What is it](#what-is-it)
 - [Roadmap](#where-is-it-going)
+- [Feature Support](#feature-support)
 - [Getting started](#getting-started)
-  - [Setup](#setup)
-    - [Windows](#windows)
-    - [Mac](#mac)
-    - [Linux](#linux)
-    - [Docker](#docker)
-    - [Running manually](#running-manually)
+  - [Windows](#windows)
+  - [Mac](#mac)
+  - [Linux](#linux)
+  - [Docker](#docker)
+  - [Running manually](#running-manually)
 - [Authentication](#authentication)
+  - [With Docker](#with-docker)
 - [Startup Quest](#startup-quest)
-
+- [Deployment](#deployment)
 
 ## Who is this for?
 
@@ -41,7 +42,7 @@ It's especially well-suited for businesses given its security-first 🔒 and ope
 
 DataLine is an AI-driven data analysis and visualization tool.
 
-It's privacy-focused, storing everything on your device. No  ☁️, only ☀️!
+It's privacy-focused, storing everything on your device. No ☁️, only ☀️!
 
 It hides your data from the LLMs used by default, but this can be disabled if the data is not deemed sensitive.
 
@@ -56,6 +57,7 @@ This is meant to enable non-technical folks to query data and aid data analysts 
 But you can still influence the direction we go in. We're building this for you, so you have the biggest say.
 
 ## Feature Support
+
 - [x] Broad DB support: Postgres, MySQL, Snowflake, CSV, SQLite, and more
 - [x] Generating and executing SQL from natural language
 - [x] Ability to modify SQL results, save them, and re-run
@@ -65,6 +67,7 @@ But you can still influence the direction we go in. We're building this for you,
 - [x] Modifying chart queries and re-rendering/refreshing charts
 
 With a lot more coming soon. You can still influence what we build, so if you're a user and you're down for it, we'd love to interview you! Book some time with one of us here:
+
 - [Rami](https://calendly.com/ramiawar/quick)
 - [Anthony](https://calendly.com/anthonymalkoun)
 
@@ -127,7 +130,7 @@ Check the [backend](./backend/README.md) and [frontend](./frontend/README.md) re
 
 ## Authentication
 
-DataLine also supports basic auth 🔒 in self-hosted mode 🥳 in case you're hosting it and would like to secure it with a username/password. 
+DataLine also supports basic auth 🔒 in self-hosted mode 🥳 in case you're hosting it and would like to secure it with a username/password.
 
 Auth is NOT supported ❌ when running the DataLine executable.
 
@@ -136,10 +139,9 @@ To enable authentication on the self-hosted version, add the environment variabl
 ### With Docker
 
 Inject the env vars with the docker run command as follows:
-```docker run -p 7377:7377 -v dataline:/home/.dataline --name dataline -e AUTH_USERNAME=admin -e AUTH_PASSWORD=admin ramiawar/dataline:latest```
+`docker run -p 7377:7377 -v dataline:/home/.dataline --name dataline -e AUTH_USERNAME=admin -e AUTH_PASSWORD=admin ramiawar/dataline:latest`
 
 We plan on supporting multiple user auth in the future, but for now it supports a single user by default.
-
 
 ### Startup Quest
 
@@ -154,3 +156,10 @@ Go through the following checklist to explore DataLine's features!
 - [ ] Try asking for a chart!
 - [ ] To really challenge it, ask a question that is answered with multiple results (charts, tables, etc.) - [example](https://www.youtube.com/watch?v=6ouSok9bOVo)
 - [ ] Add a profile picture
+
+### Deployment
+
+The one thing you must configure when deploying DataLine to a custom domain is CORS allowed origins.
+To do this, add the environment variable `ALLOWED_ORIGINS` (comma separated list of origins) to your domain name(s).
+
+By default, it is set to `http://localhost:7377,http://0.0.0.0:7377` to make it work with local Docker and local binaries.

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,6 +26,9 @@ poetry shell # Active python environment (makes alembic command available)
 alembic upgrade head # Run migrations
 ```
 
+# CORS settings
+Set the environment variable `ALLOWED_ORIGINS` to a comma-separated list of origins if you're deploying this to a custom domain.
+
 ## Environment setup
 
 Currently, the environment can be setup through the settings page on the frontend.

--- a/backend/dataline/app.py
+++ b/backend/dataline/app.py
@@ -41,7 +41,7 @@ class App(fastapi.FastAPI):
         super().__init__(title="Dataline API", lifespan=lifespan)
         self.add_middleware(
             CORSMiddleware,
-            allow_origins=["*"],
+            allow_origins=config.allowed_origins.split(","),
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],

--- a/backend/dataline/config.py
+++ b/backend/dataline/config.py
@@ -44,6 +44,9 @@ class Config(BaseSettings):
 
     spa_mode: bool = False
 
+    # CORS settings
+    allowed_origins: str = "http://localhost:7377,http://0.0.0.0:7377"  # comma separated list of origins
+
     @property
     def has_auth(self) -> bool:
         return bool(self.auth_username and self.auth_password)

--- a/backend/dataline/main.py
+++ b/backend/dataline/main.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 import uvicorn
-from alembic import command
-from alembic.config import Config
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from alembic import command
+from alembic.config import Config
 from dataline.app import App
 from dataline.config import IS_BUNDLED, config
 from dataline.old_models import SuccessResponse


### PR DESCRIPTION
# Context 

When dealing with CORS and including credentials (such as cookies, HTTP authentication, or client-side SSL certificates) in your requests, there are specific security reasons why you cannot set the Access-Control-Allow-Origin header to *.

### Why can't we use "*" with credentials?

- Credentials Exposure: Allowing any origin (*) to access resources with credentials means that any website can potentially make requests to your backend while including sensitive credentials (like session cookies). This could lead to security vulnerabilities where an attacker could craft a malicious site to exploit user sessions or sensitive data.

- W3C CORS Standard: According to the CORS specification, if a request is made with credentials (withCredentials: true), the server must specify an explicit origin (not *) in the Access-Control-Allow-Origin header. This is a security measure to ensure that only specific, trusted origins can make authenticated requests.


# Solution

Add configurable allowed headers, with a default value of `http://localhost:7377,http://0.0.0.0:7377`.