### PR TITLE
Refresh db schema!

### DIFF
--- a/backend/dataline/api/connection/router.py
+++ b/backend/dataline/api/connection/router.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, UploadFile
 from pydantic import BaseModel
 
-from dataline.config import config
 from dataline.models.connection.schema import (
     DB_SAMPLES,
     ConnectionOut,
@@ -153,3 +152,13 @@ async def get_sample_connections() -> SuccessListResponse[SampleOut]:
             for key, sample in DB_SAMPLES.items()
         ]
     )
+
+
+@router.post("/connection/{connection_id}/refresh")
+async def refresh_connection_schema(
+    connection_id: UUID,
+    session: AsyncSession = Depends(get_session),
+    connection_service: ConnectionService = Depends(ConnectionService),
+) -> SuccessResponse[ConnectionOut]:
+    updated_connection = await connection_service.refresh_connection_schema(session, connection_id)
+    return SuccessResponse(data=updated_connection)

--- a/backend/dataline/services/connection.py
+++ b/backend/dataline/services/connection.py
@@ -60,7 +60,7 @@ class ConnectionService:
     async def delete_connection(self, session: AsyncSession, connection_id: UUID) -> None:
         await self.connection_repo.delete_by_uuid(session, connection_id)
 
-    async def get_connection_details(self, dsn: str) -> SQLDatabase:
+    async def get_db_from_dsn(self, dsn: str) -> SQLDatabase:
         # Check if connection can be established before saving it
         try:
             db = SQLDatabase.from_uri(dsn)
@@ -122,7 +122,7 @@ class ConnectionService:
                 raise NotUniqueError("Connection DSN already exists.")
 
             # Check if connection can be established before saving it
-            db = await self.get_connection_details(data.dsn)
+            db = await self.get_db_from_dsn(data.dsn)
             update.dsn = str(db._engine.url.render_as_string(hide_password=False))
             update.database = db._engine.url.database
             update.dialect = db.dialect
@@ -146,7 +146,7 @@ class ConnectionService:
         is_sample: bool = False,
     ) -> ConnectionOut:
         # Check if connection can be established before saving it
-        db = await self.get_connection_details(dsn)
+        db = await self.get_db_from_dsn(dsn)
         # get potentially modified dsn (eg. if localhost was replaced with host.docker.internal)
         dsn = str(db._engine.url.render_as_string(hide_password=False))
         if not connection_type:
@@ -284,7 +284,7 @@ class ConnectionService:
         connection = await self.connection_repo.get_by_uuid(session, connection_id)
 
         # Get the latest schema information
-        db = await self.get_connection_details(connection.dsn)
+        db = await self.get_db_from_dsn(connection.dsn)
 
         # Create new ConnectionOptions with updated schema information
         new_schemas = [

--- a/backend/dataline/services/connection.py
+++ b/backend/dataline/services/connection.py
@@ -272,6 +272,15 @@ class ConnectionService:
             os.unlink(temp_file_path)
 
     async def refresh_connection_schema(self, session: AsyncSession, connection_id: UUID) -> ConnectionOut:
+        """
+        Refresh the schema of a connection. Flow of the function:
+        1. Get the connection details from the database
+        2. Get the latest schema information from the database (using DatalineSQLDatabase)
+        3. Create new ConnectionOptions with schema information from step 2
+        4. Fetch stored ConnectionOptions from the database and, if it exists, merge with new schema information
+        5. Sort schemas and tables by name
+        6. Update the connection with new options
+        """
         connection = await self.connection_repo.get_by_uuid(session, connection_id)
 
         # Get the latest schema information

--- a/backend/dataline/services/connection.py
+++ b/backend/dataline/services/connection.py
@@ -286,18 +286,20 @@ class ConnectionService:
         # Get the latest schema information
         db = await self.get_db_from_dsn(connection.dsn)
 
+        old_options = connection.options
+        enabled_default = old_options is None  # if no options existed, everything was enabled by default
+
         # Create new ConnectionOptions with updated schema information
         new_schemas = [
             ConnectionSchema(
                 name=schema,
-                tables=[ConnecitonSchemaTable(name=table, enabled=False) for table in tables],
-                enabled=False,
+                tables=[ConnecitonSchemaTable(name=table, enabled=enabled_default) for table in tables],
+                enabled=enabled_default,
             )
             for schema, tables in db._all_tables_per_schema.items()
         ]
 
         # Merge the new schema information with existing options
-        old_options = connection.options
         if old_options:
             existing_schemas = {schema["name"]: schema for schema in old_options["schemas"]}
             for new_schema in new_schemas:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -173,6 +173,17 @@ const createConversation = async (connectionId: string, name: string) => {
   return response.data;
 };
 
+export type RefreshConnectionSchemaResult = ApiResponse<IConnection>;
+const refreshConnectionSchema = async (
+  connectionId: string
+): Promise<RefreshConnectionSchemaResult> => {
+  const response = await backendApi<RefreshConnectionSchemaResult>({
+    url: `/connection/${connectionId}/refresh`,
+    method: "post",
+  });
+  return response.data;
+};
+
 export type ConversationUpdateResult = ApiResponse<void>;
 const updateConversation = async (
   conversationId: string,
@@ -452,6 +463,7 @@ export const api = {
   createFileConnection,
   updateConnection,
   deleteConnection,
+  refreshConnectionSchema,
   listConnections,
   listConversations,
   generateConversationTitle,

--- a/frontend/src/components/Connection/ConnectionEditor.tsx
+++ b/frontend/src/components/Connection/ConnectionEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { IConnectionOptions, IEditConnection } from "@components/Library/types";
-import { XMarkIcon } from "@heroicons/react/24/outline";
+import { ArrowPathIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import { AlertIcon, AlertModal } from "@components/Library/AlertModal";
 import { enqueueSnackbar } from "notistack";
@@ -349,19 +349,24 @@ export const ConnectionEditor = () => {
           </div>
 
           <div className="sm:col-span-6">
-            <label
-              htmlFor="schema"
-              className="block text-sm font-medium leading-6 text-white"
-            >
-              Schema options
-            </label>
-            <div className="flex justify-between items-center mb-2">
+            <div className="flex items-center mb-2 gap-x-2">
+              <label
+                htmlFor="schema"
+                className="block text-sm font-medium leading-6 text-white"
+              >
+                Schema options
+              </label>
               <Button
                 onClick={() => refreshSchema(connectionId)}
-                color="blue"
+                plain
                 disabled={isRefreshing}
               >
-                {isRefreshing ? "Refreshing..." : "Refresh Schema"}
+                <ArrowPathIcon
+                  className={classNames(
+                    "w-6 h-6 [&>path]:stroke-[2] group-hover:-rotate-6",
+                    isRefreshing ? "animate-spin" : ""
+                  )}
+                />
               </Button>
             </div>
             {editFields.options && (

--- a/frontend/src/hooks/connections.ts
+++ b/frontend/src/hooks/connections.ts
@@ -7,7 +7,11 @@ import {
   queryOptions,
 } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
-import { DatabaseFileType, IEditConnection } from "@/components/Library/types";
+import {
+  DatabaseFileType,
+  IConnection,
+  IEditConnection,
+} from "@/components/Library/types";
 import { CONVERSATIONS_QUERY_KEY } from "./conversations";
 import { getBackendStatusQuery } from "@/hooks/settings";
 import { useEffect } from "react";
@@ -204,5 +208,31 @@ export function useGetSamples() {
     queryKey: ["DB_SAMPLES"],
     queryFn: async () => (await api.getSamples()).data,
     enabled: isSuccess,
+  });
+}
+
+export function useRefreshConnectionSchema(
+  onRefreshSuccess: (data: IConnection) => void
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (connectionId: string) =>
+      (await api.refreshConnectionSchema(connectionId)).data,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: getConnectionsQuery().queryKey,
+      });
+      enqueueSnackbar({
+        variant: "success",
+        message: "Schema refreshed successfully",
+      });
+      onRefreshSuccess(data);
+    },
+    onError(error) {
+      enqueueSnackbar({
+        variant: "error",
+        message: "Failed to refresh schema: " + error.message,
+      });
+    },
   });
 }


### PR DESCRIPTION
- Add endpoint to refresh schema for a given connection
  - New schemas/tables are disabled by default
- Add refresh button in Connection Editor to do the refreshing
  - Smooth transition if new schema/table added or removed
  - Nice refresh animation