### PR TITLE
Scroll to top when navigating, except in conversations

### DIFF
--- a/frontend/src/components/Home/Main.tsx
+++ b/frontend/src/components/Home/Main.tsx
@@ -3,7 +3,7 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@components/Catalyst/alert";
-import { Outlet } from "@tanstack/react-router";
+import { Outlet, useLocation } from "@tanstack/react-router";
 import { Sidebar } from "./Sidebar";
 import { OpenAIKeyPopup } from "../Settings/OpenAIKeyPopup";
 import { Spinner } from "../Spinner/Spinner";
@@ -15,7 +15,7 @@ import {
 } from "@/hooks";
 
 import "simplebar-react/dist/simplebar.min.css";
-import React from "react";
+import React, { useEffect } from "react";
 import Login from "@components/Library/Login";
 import { useQuery } from "@tanstack/react-query";
 import { isAuthenticatedQuery } from "@/hooks/auth";
@@ -38,6 +38,16 @@ export const AppLayout: React.FC = () => {
   const { data: isAuthenticated, isPending: isPendingAuth } = useQuery(
     isAuthenticatedQuery()
   );
+  const pathname = useLocation({ select: (location) => location.pathname });
+
+  useEffect(() => {
+    // This fixes the issue of the main panel (e.g. settings, connections...) starting from the bottom
+    // when navigating, especially when coming from a chat page.
+    // regex match for "/chat/.+"
+    if (!pathname.match(/^\/chat\/.+$/)) {
+      window.scrollTo({ top: 0, behavior: "instant" });
+    }
+  }, [pathname]);
 
   if (isFetchedHealthy && !isHealthy) {
     return (


### PR DESCRIPTION
This was an annoying bug where if you navigate to the settings page or the connections page, the scrollbar won't be at the top unless you were already at the top:

Issue recording:


https://github.com/user-attachments/assets/e9e34601-923a-4257-93e1-1e299b46dc98


This branch's fix recording:


https://github.com/user-attachments/assets/bd119d32-9901-4649-adaa-3c9ba1467dba

