### PR TITLE
feat(conversation): hide SQL blocks by default based on user preference

### DIFF
--- a/frontend/src/components/Conversation/Message.tsx
+++ b/frontend/src/components/Conversation/Message.tsx
@@ -1,7 +1,7 @@
 import logo from "@/assets/images/logo_md.png";
 import { IMessageWithResultsOut } from "@components/Library/types";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
-import { useGetAvatar } from "@/hooks";
+import { useGetAvatar, useGetUserProfile } from "@/hooks";
 import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 import { InfoTooltip } from "@components/Library/Tooltip";
 import { MessageResultRenderer } from "./MessageResultRenderer";
@@ -47,6 +47,8 @@ export const Message = ({
   className?: string;
   streaming?: boolean;
 }) => {
+  const { data: profile } = useGetUserProfile();
+  const hideSqlPreference = profile?.hide_sql_preference;
   return (
     <div
       className={classNames(
@@ -87,6 +89,7 @@ export const Message = ({
           <MessageResultRenderer
             initialResults={message.results || []}
             messageId={message.message.id || ""}
+            hideSqlByDefault={hideSqlPreference}
           />
         </div>
       </div>

--- a/frontend/src/components/Conversation/MessageResultRenderer.tsx
+++ b/frontend/src/components/Conversation/MessageResultRenderer.tsx
@@ -104,9 +104,11 @@ function getResultGroups(results: IResultType[]) {
 export const MessageResultRenderer = ({
   initialResults,
   messageId,
+  hideSqlByDefault,
 }: {
   initialResults: IResultType[];
   messageId: string;
+  hideSqlByDefault?: boolean;
 }) => {
   const [results, setResults] = useState(initialResults);
   const { groups: resultGroups, unlinkedGroup } = useMemo(
@@ -268,6 +270,8 @@ export const MessageResultRenderer = ({
                     result.result_id
                   )}
                   forChart={result.content.for_chart}
+                  hideSqlByDefault={hideSqlByDefault}
+                  resultType={result.type}
                 />
               )) ||
               (result.type === "CHART_GENERATION_RESULT" && (

--- a/frontend/src/hooks/settings.ts
+++ b/frontend/src/hooks/settings.ts
@@ -157,6 +157,7 @@ export function useUpdateUserInfo(options = {}) {
       openai_base_url?: string;
       sentry_enabled?: boolean;
       analytics_enabled?: boolean;
+      hide_sql_preference?: boolean;
     }) => (await api.updateUserInfo(payload)).data,
     onSuccess() {
       enqueueSnackbar({


### PR DESCRIPTION
## Closes #384

### Description

This PR implements the feature to allow users to hide SQL code blocks by default in their conversation view, controlled by a user setting (`hide_sql_preference`).

Previously, even if the `hide_sql_preference` was set to true, SQL blocks might not hide as expected. This was because the `dialect` information, used to identify SQL blocks, was not consistently available, particularly for results of type `SQL_QUERY_STRING_RESULT` where the backend doesn't currently supply the dialect.

### Changes Made

1.  **`frontend/src/components/Conversation/Message.tsx`**:
    *   The `hideSqlPreference` (from `profile?.hide_sql_preference`) is correctly passed to `MessageResultRenderer`.

2.  **`frontend/src/components/Conversation/MessageResultRenderer.tsx`**:
    *   The `result.type` is now passed as a `resultType` prop to the [CodeBlock](cci:1://file:///home/yashparmar/Documents/Yash/dataline/frontend/src/components/Conversation/CodeBlock.tsx:92:0-423:2) component. This allows [CodeBlock](cci:1://file:///home/yashparmar/Documents/Yash/dataline/frontend/src/components/Conversation/CodeBlock.tsx:92:0-423:2) to infer the nature of the content even if `dialect` is missing.

3.  **[frontend/src/components/Conversation/CodeBlock.tsx](cci:7://file:///home/yashparmar/Documents/Yash/dataline/frontend/src/components/Conversation/CodeBlock.tsx:0:0-0:0)**:
    *   The [CodeBlock](cci:1://file:///home/yashparmar/Documents/Yash/dataline/frontend/src/components/Conversation/CodeBlock.tsx:92:0-423:2) component now accepts the `resultType` prop.
    *   The logic to determine if a block should be minimized by default (`minimized` state) has been updated:
        *   It now checks `hideSqlByDefault`.
        *   It considers a block to be SQL if either `dialect?.toLowerCase() === "sql"` OR if (`resultType === "SQL_QUERY_STRING_RESULT"` and `dialect` is `undefined`). This ensures SQL blocks are correctly identified for hiding even when the backend doesn't explicitly provide the dialect.

### How to Test

1.  **Enable the preference:**
    *   Navigate to your user profile settings.
    *   Ensure the setting to "Hide SQL by default" (or similar, based on `hide_sql_preference`) is **enabled/checked**.
2.  **Verify in conversation:**
    *   Go to a conversation or start a new one that generates SQL query strings.
    *   **Expected:** The SQL code block should appear minimized/hidden by default.
    *   You should still be able to manually expand the SQL code block.
3.  **Disable the preference:**
    *   Navigate back to your user profile settings.
    *   Ensure the setting to "Hide SQL by default" is **disabled/unchecked**.
4.  **Verify in conversation:**
    *   Return to the conversation or generate a new SQL query.
    *   **Expected:** The SQL code block should now appear fully visible by default.
