### PR TITLE
fix: persist rerun SQL results across conversation reloads

### DIFF
--- a/backend/dataline/api/conversation/router.py
+++ b/backend/dataline/api/conversation/router.py
@@ -20,6 +20,7 @@ from dataline.services.connection import ConnectionService
 from dataline.services.conversation import ConversationService
 from dataline.services.llm_flow.toolkit import execute_sql_query
 from dataline.services.llm_flow.utils import DatalineSQLDatabase as SQLDatabase
+from dataline.services.result import ResultService
 from dataline.utils.posthog import posthog_capture
 from dataline.utils.utils import generate_with_errors
 
@@ -123,7 +124,7 @@ def query(
     )
 
 
-@router.get("/conversation/{conversation_id}/run-sql")
+@router.post("/conversation/{conversation_id}/run-sql")
 async def execute_sql(
     conversation_id: UUID,
     sql: str,
@@ -131,6 +132,7 @@ async def execute_sql(
     session: Annotated[AsyncSession, Depends(get_session)],
     conversation_service: Annotated[ConversationService, Depends()],
     connection_service: Annotated[ConnectionService, Depends()],
+    result_service: Annotated[ResultService, Depends()],
     background_tasks: BackgroundTasks,
     limit: int = 10,
     execute: bool = True,
@@ -156,6 +158,9 @@ async def execute_sql(
         for_chart=False,
         linked_id=linked_id,
     )
+    stored_result = await result_service.upsert_sql_run_result(session, conversation_id, linked_id, query_run_data)
+    result.result_id = stored_result.id
+    result.created_at = stored_result.created_at
 
     return SuccessResponse(data=result.serialize_result())
 

--- a/backend/dataline/repositories/result.py
+++ b/backend/dataline/repositories/result.py
@@ -48,3 +48,24 @@ class ResultRepository(BaseRepository[ResultModel, ResultCreate, ResultUpdate]):
             raise NotFoundError(f"Could not find chart for result_id: {sql_string_result_id}")
 
         return chart[0]
+
+    async def get_run_from_sql_query(self, session: AsyncSession, sql_string_result_id: UUID) -> ResultModel:
+        query = (
+            select(ResultModel)
+            .filter_by(linked_id=sql_string_result_id)
+            .filter(ResultModel.type == QueryResultType.SQL_QUERY_RUN_RESULT.value)
+        )
+        result = await session.execute(query)
+        run = result.fetchone()
+        if not run:
+            raise NotFoundError(f"Could not find SQL run for result_id: {sql_string_result_id}")
+
+        return run[0]
+
+    async def get_message_from_result(self, session: AsyncSession, result_id: UUID) -> MessageModel:
+        query = select(MessageModel).join(ResultModel).where(ResultModel.id == result_id)
+        result = await session.execute(query)
+        message = result.scalar_one_or_none()
+        if message is None:
+            raise NotFoundError(f"Could not find message for result_id: {result_id}")
+        return message

--- a/backend/dataline/services/result.py
+++ b/backend/dataline/services/result.py
@@ -11,8 +11,14 @@ from fastapi.responses import StreamingResponse
 from dataline.errors import ValidationError
 from dataline.models.connection.schema import Connection
 from dataline.models.llm_flow.enums import QueryResultType
-from dataline.models.llm_flow.schema import ChartGenerationResultContent, SQLQueryStringResultContent
-from dataline.models.result.schema import ChartRefreshOut, ResultUpdate
+from dataline.models.llm_flow.schema import (
+    ChartGenerationResultContent,
+    QueryRunData,
+    SQLQueryRunResultContent,
+    SQLQueryStringResultContent,
+)
+from dataline.models.result.model import ResultModel
+from dataline.models.result.schema import ChartRefreshOut, ResultCreate, ResultUpdate
 from dataline.repositories.base import AsyncSession, NotFoundError
 from dataline.repositories.result import ResultRepository
 from dataline.services.llm_flow.llm_calls.chart_generator import ChartType
@@ -45,6 +51,54 @@ class ResultService:
         else:
             # Just update sql, no chart involved
             await self._update_sql(session, result_id, sql)
+
+    async def upsert_sql_run_result(
+        self,
+        session: AsyncSession,
+        conversation_id: UUID,
+        sql_query_string_id: UUID,
+        query_run_data: QueryRunData,
+    ) -> ResultModel:
+        query_string_result = await self.result_repo.get_by_uuid(session, sql_query_string_id)
+        if query_string_result.type != QueryResultType.SQL_QUERY_STRING_RESULT.value:
+            raise ValueError("The linked result must be an SQL_QUERY_STRING_RESULT")
+
+        message = await self.result_repo.get_message_from_result(session, sql_query_string_id)
+        if message.conversation_id != conversation_id:
+            raise ValueError("The linked SQL result does not belong to this conversation")
+
+        created_at = datetime.now()
+        try:
+            existing_run = await self.result_repo.get_run_from_sql_query(session, sql_query_string_id)
+            existing_content = SQLQueryRunResultContent.model_validate_json(existing_run.content)
+            is_secure = existing_content.is_secure
+        except NotFoundError:
+            existing_run = None
+            is_secure = bool(message.options and message.options.get("secure_data", False))
+
+        content = SQLQueryRunResultContent(
+            data=query_run_data,
+            is_secure=is_secure,
+            for_chart=False,
+        ).model_dump_json()
+
+        if existing_run is None:
+            return await self.result_repo.create(
+                session,
+                ResultCreate(
+                    created_at=created_at,
+                    content=content,
+                    type=QueryResultType.SQL_QUERY_RUN_RESULT.value,
+                    message_id=query_string_result.message_id,
+                    linked_id=sql_query_string_id,
+                ),
+            )
+
+        return await self.result_repo.update_by_uuid(
+            session,
+            existing_run.id,
+            ResultUpdate(created_at=created_at, content=content),
+        )
 
     async def _validate_chart_sql(
         self,

--- a/backend/tests/test_result_service.py
+++ b/backend/tests/test_result_service.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dataline.models.llm_flow.enums import QueryResultType
+from dataline.models.llm_flow.schema import QueryRunData, SQLQueryRunResultContent
+from dataline.models.message.schema import BaseMessageType, MessageCreate, MessageOptions
+from dataline.models.result.schema import ResultCreate
+from dataline.models.conversation.schema import ConversationOut
+from dataline.repositories.base import AsyncSession, NotFoundError
+from dataline.repositories.message import MessageRepository
+from dataline.repositories.result import ResultRepository
+from dataline.services.result import ResultService
+
+
+def query_run_data() -> QueryRunData:
+    return QueryRunData(columns=["count"], rows=[[3]])
+
+
+def test_run_sql_route_uses_post(client: TestClient) -> None:
+    operations = client.app.openapi()["paths"]["/conversation/{conversation_id}/run-sql"]
+
+    assert "post" in operations
+    assert "get" not in operations
+
+
+@pytest.mark.asyncio
+async def test_upsert_sql_run_result_creates_first_persisted_run() -> None:
+    conversation_id = uuid4()
+    query_id = uuid4()
+    message_id = uuid4()
+    repository = AsyncMock(spec=ResultRepository)
+    repository.get_by_uuid.return_value = Mock(
+        id=query_id,
+        message_id=message_id,
+        type=QueryResultType.SQL_QUERY_STRING_RESULT.value,
+    )
+    repository.get_run_from_sql_query.side_effect = NotFoundError("missing")
+    repository.get_message_from_result.return_value = Mock(
+        conversation_id=conversation_id, options={"secure_data": True}
+    )
+    stored = Mock()
+    repository.create.return_value = stored
+
+    service = ResultService(result_repo=repository)
+    result = await service.upsert_sql_run_result(  # type: ignore[arg-type]
+        None, conversation_id, query_id, query_run_data()
+    )
+
+    assert result is stored
+    create = repository.create.await_args.args[1]
+    assert create.message_id == message_id
+    assert create.linked_id == query_id
+    assert create.type == QueryResultType.SQL_QUERY_RUN_RESULT.value
+    content = SQLQueryRunResultContent.model_validate_json(create.content)
+    assert content.data.columns == ["count"]
+    assert content.data.rows == [[3]]
+    assert content.is_secure is True
+    assert content.for_chart is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_sql_run_result_updates_existing_run() -> None:
+    conversation_id = uuid4()
+    query_id = uuid4()
+    run_id = uuid4()
+    repository = AsyncMock(spec=ResultRepository)
+    repository.get_by_uuid.return_value = Mock(
+        id=query_id,
+        message_id=uuid4(),
+        type=QueryResultType.SQL_QUERY_STRING_RESULT.value,
+    )
+    repository.get_run_from_sql_query.return_value = Mock(
+        id=run_id,
+        content=SQLQueryRunResultContent(
+            data=QueryRunData(columns=["old"], rows=[[1]]),
+            is_secure=True,
+            for_chart=False,
+        ).model_dump_json(),
+    )
+    repository.get_message_from_result.return_value = Mock(
+        conversation_id=conversation_id, options={"secure_data": False}
+    )
+    stored = Mock()
+    repository.update_by_uuid.return_value = stored
+
+    service = ResultService(result_repo=repository)
+    result = await service.upsert_sql_run_result(  # type: ignore[arg-type]
+        None, conversation_id, query_id, query_run_data()
+    )
+
+    assert result is stored
+    record_id = repository.update_by_uuid.await_args.args[1]
+    update = repository.update_by_uuid.await_args.args[2]
+    assert record_id == run_id
+    assert isinstance(update.created_at, datetime)
+    content = SQLQueryRunResultContent.model_validate_json(update.content)
+    assert content.data.rows == [[3]]
+    assert content.is_secure is True
+    repository.create.assert_not_awaited()
+    repository.get_message_from_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upsert_sql_run_result_rejects_non_query_parent() -> None:
+    query_id = uuid4()
+    repository = AsyncMock(spec=ResultRepository)
+    repository.get_by_uuid.return_value = Mock(
+        id=query_id,
+        message_id=uuid4(),
+        type=QueryResultType.CHART_GENERATION_RESULT.value,
+    )
+
+    service = ResultService(result_repo=repository)
+    with pytest.raises(ValueError, match="SQL_QUERY_STRING_RESULT"):
+        await service.upsert_sql_run_result(None, uuid4(), query_id, query_run_data())  # type: ignore[arg-type]
+
+    repository.get_run_from_sql_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_sql_run_result_rejects_cross_conversation_parent() -> None:
+    query_id = uuid4()
+    repository = AsyncMock(spec=ResultRepository)
+    repository.get_by_uuid.return_value = Mock(
+        id=query_id,
+        message_id=uuid4(),
+        type=QueryResultType.SQL_QUERY_STRING_RESULT.value,
+    )
+    repository.get_message_from_result.return_value = Mock(conversation_id=uuid4(), options={"secure_data": False})
+
+    service = ResultService(result_repo=repository)
+    with pytest.raises(ValueError, match="does not belong"):
+        await service.upsert_sql_run_result(None, uuid4(), query_id, query_run_data())  # type: ignore[arg-type]
+
+    repository.get_run_from_sql_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upsert_sql_run_result_is_visible_after_database_reload(
+    session: AsyncSession,
+    sample_conversation: ConversationOut,
+) -> None:
+    message_repo = MessageRepository()
+    result_repo = ResultRepository()
+    message = await message_repo.create(
+        session,
+        MessageCreate(
+            role=BaseMessageType.AI.value,
+            content="query",
+            conversation_id=sample_conversation.id,
+            options=MessageOptions(secure_data=True),
+        ),
+    )
+    query = await result_repo.create(
+        session,
+        ResultCreate(
+            content='{"sql":"select 2","for_chart":false}',
+            type=QueryResultType.SQL_QUERY_STRING_RESULT.value,
+            message_id=message.id,
+        ),
+    )
+    old_run = await result_repo.create(
+        session,
+        ResultCreate(
+            content=SQLQueryRunResultContent(
+                data=QueryRunData(columns=["value"], rows=[[1]]),
+                is_secure=True,
+                for_chart=False,
+            ).model_dump_json(),
+            type=QueryResultType.SQL_QUERY_RUN_RESULT.value,
+            message_id=message.id,
+            linked_id=query.id,
+        ),
+    )
+
+    service = ResultService(result_repo=result_repo)
+    persisted = await service.upsert_sql_run_result(
+        session,
+        sample_conversation.id,
+        query.id,
+        QueryRunData(columns=["value"], rows=[[2]]),
+    )
+    old_run_id = old_run.id
+    persisted_id = persisted.id
+    session.expire_all()
+    reloaded = await result_repo.get_by_uuid(session, old_run_id)
+    content = SQLQueryRunResultContent.model_validate_json(reloaded.content)
+
+    assert persisted_id == old_run_id
+    assert content.data.rows == [[2]]
+    assert content.is_secure is True

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,7 +6,7 @@ import {
   IMessageOptions,
   IMessageOut,
   IMessageWithResultsOut,
-  IResult,
+  ISQLQueryRunResult,
   IUserInfo,
 } from "./components/Library/types";
 import { IEditConnection } from "./components/Library/types";
@@ -305,7 +305,7 @@ const streamingQuery = async ({
   });
 };
 
-export type RunSQLResult = ApiResponse<IResult>;
+export type RunSQLResult = ApiResponse<ISQLQueryRunResult>;
 const runSQL = async (
   conversationId: string,
   code: string,
@@ -314,6 +314,7 @@ const runSQL = async (
   return (
     await backendApi<RunSQLResult>({
       url: `/conversation/${conversationId}/run-sql`,
+      method: "post",
       params: { sql: code, linked_id: linkedId },
     })
   ).data;

--- a/frontend/src/components/Conversation/CodeBlock.tsx
+++ b/frontend/src/components/Conversation/CodeBlock.tsx
@@ -22,7 +22,7 @@ import {
   AlertTitle,
 } from "../Catalyst/alert";
 import { Button } from "../Catalyst/button";
-import { Dialect } from "../Library/types";
+import { Dialect, ISQLQueryRunResult } from "../Library/types";
 import Minimizer from "../Minimizer/Minimizer";
 
 function copyToClipboard(text: string) {
@@ -103,7 +103,7 @@ export const CodeBlock = ({
   code: string;
   resultId: string;
   dialect?: string;
-  onUpdateSQLRunResult: (sql_string_result_id: string, arg: string) => void;
+  onUpdateSQLRunResult: (sql_string_result_id: string, result: ISQLQueryRunResult) => void;
   onSaveSQLStringResult: (
     data?: { created_at: string; chartjs_json: string } | void
   ) => void;
@@ -140,10 +140,8 @@ export const CodeBlock = ({
         onSettled: (data, error) => {
           if (error) {
             console.error("onsettled error in: ", error);
-          } else {
-            if (data?.content) {
-              onUpdateSQLRunResult(resultId, data.content as string);
-            }
+          } else if (data) {
+            onUpdateSQLRunResult(resultId, data);
           }
         },
       }

--- a/frontend/src/components/Conversation/MessageResultRenderer.tsx
+++ b/frontend/src/components/Conversation/MessageResultRenderer.tsx
@@ -1,6 +1,7 @@
 import {
   IResultType,
   ISQLQueryStringResult,
+  ISQLQueryRunResult,
   ISelectedTablesResult,
 } from "@components/Library/types";
 import { useMemo, useState } from "react";
@@ -120,10 +121,10 @@ export const MessageResultRenderer = ({
   // Necessary since the results are only present at this level and the codeblock can't modify them
   function updateLinkedSQLRunResult(
     sql_string_result_id: string,
-    content: string
+    persistedResult: ISQLQueryRunResult
   ) {
     // != null, rules out both null and undefined
-    if (results != null && content != null) {
+    if (results != null && persistedResult != null) {
       // Remove SQL query run result linked to this ID if any
       const newResults = results?.filter(
         (result) =>
@@ -133,14 +134,7 @@ export const MessageResultRenderer = ({
           )
       );
 
-      const updatedResults = [
-        ...newResults,
-        {
-          type: "SQL_QUERY_RUN_RESULT",
-          linked_id: sql_string_result_id,
-          content,
-        },
-      ] as IResultType[];
+      const updatedResults = [...newResults, persistedResult];
       setResults(updatedResults);
     }
   }

--- a/frontend/src/hooks/messages.ts
+++ b/frontend/src/hooks/messages.ts
@@ -2,8 +2,8 @@ import { api, RefreshChartResult } from "@/api";
 import {
   IMessageOut,
   IMessageWithResultsOut,
-  IResult,
   IResultType,
+  ISQLQueryRunResult,
   QueryStreamingEvent,
 } from "@/components/Library/types";
 import {
@@ -190,7 +190,7 @@ export function useRunSql(
     sql: string;
     resultId: string;
   },
-  options: UseMutationOptions<IResult> = {}
+  options: UseMutationOptions<ISQLQueryRunResult> = {}
 ) {
   return useMutation({
     mutationFn: async () =>
@@ -218,7 +218,7 @@ export function useRunSqlInConversation(
     sql: string;
     resultId: string;
   },
-  options: UseMutationOptions<IResult> = {}
+  options: UseMutationOptions<ISQLQueryRunResult> = {}
 ) {
   const { conversationId } = useParams({ from: "/_app/chat/$conversationId" });
   return useMutation({


### PR DESCRIPTION
## Problem

Issue #263 reproduces a persistence mismatch:

1. edit an SQL string
2. press Run
3. save the SQL
4. leave and reopen the conversation

The rerun result only replaced React state. The backend returned an ephemeral `SQL_QUERY_RUN_RESULT` and never updated the stored linked result, so reopening loaded the old rows.

## Fix

- make the state-changing `run-sql` route POST
- update the existing linked run result, or create it for historical data that has none
- return the persisted result identity and timestamp to the frontend
- replace local state with the complete persisted result
- preserve the existing Secure Data marker
- reject a linked SQL result from another conversation

## Verification

- focused persistence and API contract tests: 6 passed
- full non-expensive backend suite: 31 passed / 6 existing explicit skips
- database reload regression: writes old rows, updates, expires ORM state, reloads the same result ID, and observes new rows
- changed-file Black and frontend ESLint: pass
- backend compileall: pass
- frontend TypeScript + Vite production build: pass
- remote fork Backend/Frontend CI: https://github.com/lindixu6-hash/dataline/actions/runs/32064489534

No OpenAI calls, production credentials, hosted services, user data, deployment, or release workflows are used.

Closes #263.